### PR TITLE
retry parsing

### DIFF
--- a/osm/_utils.py
+++ b/osm/_utils.py
@@ -87,7 +87,6 @@ def compose_up():
     print("Waiting for containers to be ready...")
     docker.compose.up(detach=True, wait=True, pull="always")
     print("Containers ready!")
-    sleep(5)
 
 
 def compose_down():

--- a/osm/cli.py
+++ b/osm/cli.py
@@ -93,7 +93,7 @@ def main():
                 ),
             ),
         )
-        pipeline.run()
+        pipeline.run(user_managed_compose=args.user_managed_compose)
     finally:
         if not args.user_managed_compose:
             compose_down()

--- a/osm/pipeline/core.py
+++ b/osm/pipeline/core.py
@@ -99,9 +99,9 @@ class Pipeline:
         self.xml_path = xml_path
         self.metrics_path = metrics_path
 
-    def run(self):
+    def run(self,user_managed_compose:bool=False):
         for parser in self.parsers:
-            parsed_data = parser.run(self.file_data)
+            parsed_data = parser.run(self.file_data,user_managed_compose=user_managed_compose)
             if isinstance(parsed_data, bytes):
                 self.savers.save_file(parsed_data, self.xml_path)
             for extractor in self.extractors:


### PR DESCRIPTION
sciencebeam container starts up slowly

this change can help by retrying but sometime the container dies as a result of a failed request.

Another strategy to take here would be figure out how to check whether the container is ready without querying the convert endpoint. There are many others and perhaps others are more suitable for polling the server status. 