### PR TITLE
Add `DEPLOYMENT_URI` to Let's Encrypt configuration

### DIFF
--- a/.github/workflows/docker-up.yml
+++ b/.github/workflows/docker-up.yml
@@ -28,9 +28,11 @@ jobs:
         run: |
           if [[ ${{ inputs.development-environment }} == 'production' ]]; then
             echo "HOST_URI=${SSH_PROD_HOST}" >> $GITHUB_ENV
+            echo "DEPLOYMENT_URI=${{ vars.PRODUCTION_DEPLOYMENT_URI }}" >> $GITHUB_ENV
           else
             echo "HOST_URI=${SSH_STAGE_HOST}" >> $GITHUB_ENV
-          fi          
+            echo "DEPLOYMENT_URI=${{ vars.STAGING_DEPLOYMENT_URI }}" >> $GITHUB_ENV
+          fi
           
       - name: Configure SSH
         env:
@@ -70,6 +72,7 @@ jobs:
           AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID}" \
           AWS_REGION="${AWS_REGION}" \
           LETSENCRYPT_ADMIN_EMAIL=${LETSENCRYPT_ADMIN_EMAIL} \
+          DEPLOYMENT_URI=${DEPLOYMENT_URI} \
           docker compose -f - up -d < ./web/deploy/docker-compose.yaml
 
       - name: Prune Docker artifacts

--- a/web/deploy/docker-compose.yaml
+++ b/web/deploy/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
         labels:
             - traefik.enable=true
             - traefik.docker.network=osm_traefik-public
-            - traefik.http.routers.osm_web_api.rule=Host("`${HOST_URI}`") && PathPrefix(`/api`)
+            - traefik.http.routers.osm_web_api.rule=Host("`${DEPLOYMENT_URI}`") && PathPrefix(`/api`)
             - "traefik.http.routers.osm_web_api.entrypoints=web,websecure"
             - traefik.http.services.osm_web_api.loadbalancer.server.port=80
             - traefik.http.routers.osm_web_api.tls=true
@@ -29,7 +29,7 @@ services:
         labels:
             - traefik.enable=true
             - traefik.docker.network=osm_traefik-public
-            - traefik.http.routers.dashboard.rule=Host("`${HOST_URI}`")
+            - traefik.http.routers.dashboard.rule=Host("`${DEPLOYMENT_URI}`")
             - traefik.http.routers.dashboard.entrypoints=web,websecure
             - traefik.http.services.dashboard.loadbalancer.server.port=8501
             - traefik.http.routers.dashboard.tls=true


### PR DESCRIPTION
The Let's Encrypt config in `docker-compose.yaml` was set incorrectly to the url of the EC2 host, but it should have been set to the URL of the site. This PR fixes that.