### PR TITLE
fix: Splitting by Journal was showing the wrong data

### DIFF
--- a/web/dashboard/main_dashboard.py
+++ b/web/dashboard/main_dashboard.py
@@ -556,12 +556,15 @@ class MainDashboard(param.Parameterized):
                     ].values[0]
                     last_year_values[selected_item] = value_last_year
 
+                    data_as_dict = sub_df.set_index("year")[raw_metric].to_dict()
+                    data = [data_as_dict.get(year, None) for year in xAxis]
+
                     series.append(
                         {
                             "id": selected_item,
                             "name": selected_item,
                             "type": "line",
-                            "data": sub_df[raw_metric].tolist(),
+                            "data": data,
                             # Shows a label at the end of the plotted line.
                             # Labels end up overlapping in some cases.
                             # To fix this, we would need to change the offset of the label
@@ -590,7 +593,7 @@ class MainDashboard(param.Parameterized):
         # time to get the same good-looking result.
         # So for the sake of delivering fast, I just round the values to 2 decimals.
         for serie in series:
-            serie["data"] = [round(v, 2) for v in serie["data"]]
+            serie["data"] = [round(v, 2) if v is not None else v for v in serie["data"]]
 
         # Default colormap is :
         # ["#5470c6", "#91cc75", "#fac858", "#ee6666", "#73c0de", "#3ba272", "#fc8452", "#9a60b4", "#ea7ccc"]


### PR DESCRIPTION
closes #81 

Before:

<img width="937" height="661" alt="image" src="https://github.com/user-attachments/assets/ca2c34c2-cfee-4b71-9e5c-c24fe450e8e6" />


After:

<img width="1070" height="646" alt="Screenshot 2025-07-31 121158" src="https://github.com/user-attachments/assets/b410a4b9-141b-4993-9b5f-202b433e83a4" />
